### PR TITLE
Delete confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/assets/common.js
+++ b/assets/common.js
@@ -138,7 +138,7 @@ Thread.prototype.delete = function() {
       _this.deletionLock = false;
       _this.object.find('.comment-delete').first().removeAttr('style');
       _this.object.find('.comment-delete').first().text(mw.msg('flowthread-ui-delete'));
-    }, 1000);
+    }, 1500);
   } else {
     var api = new mw.Api();
     api.get({

--- a/assets/common.js
+++ b/assets/common.js
@@ -133,13 +133,14 @@ Thread.prototype.delete = function() {
     this.deletionLock = true;
     this.object.find('.comment-delete').first().text(mw.msg('flowthread-ui-delete_confirmation'));
     this.object.find('.comment-delete').first().css('color', 'rgb(163, 31,8)');
+    var _this = this;
     // Set timer
     setTimeout(function () {
       console.info("TRACE: Confirmation timeout");
-      this.deletionLock = false;
-      this.object.find('.comment-delete').first().removeAttr('style');
-      this.object.find('.comment-delete').first().text(mw.msg('flowthread-ui-delete'));
-    }, 5000);
+      _this.deletionLock = false;
+      _this.object.find('.comment-delete').first().removeAttr('style');
+      _this.object.find('.comment-delete').first().text(mw.msg('flowthread-ui-delete'));
+    }, 3000);
   } else {
     var api = new mw.Api();
     api.get({

--- a/assets/common.js
+++ b/assets/common.js
@@ -134,13 +134,11 @@ Thread.prototype.delete = function() {
     this.object.find('.comment-delete').first().text(mw.msg('flowthread-ui-delete_confirmation'));
     this.object.find('.comment-delete').first().css('color', 'rgb(163, 31,8)');
     var _this = this;
-    // Set timer
     setTimeout(function () {
-      console.info("TRACE: Confirmation timeout");
       _this.deletionLock = false;
       _this.object.find('.comment-delete').first().removeAttr('style');
       _this.object.find('.comment-delete').first().text(mw.msg('flowthread-ui-delete'));
-    }, 3000);
+    }, 1000);
   } else {
     var api = new mw.Api();
     api.get({

--- a/assets/common.js
+++ b/assets/common.js
@@ -131,10 +131,13 @@ Thread.prototype.delete = function() {
   // Implements a mechanism for delete confirmation
   if (!this.deletionLock) {
     this.deletionLock = true;
-    this.object.find('.comment-delete').first().text(mw.msg('flowthread-ui-delete-confirmation'));
+    this.object.find('.comment-delete').first().text(mw.msg('flowthread-ui-delete_confirmation'));
+    this.object.find('.comment-delete').first().css('color', 'rgb(163, 31,8)');
     // Set timer
     setTimeout(function () {
+      console.info("TRACE: Confirmation timeout");
       this.deletionLock = false;
+      this.object.find('.comment-delete').first().removeAttr('style');
       this.object.find('.comment-delete').first().text(mw.msg('flowthread-ui-delete'));
     }, 5000);
   } else {

--- a/assets/common.js
+++ b/assets/common.js
@@ -37,6 +37,8 @@ function Thread() {
 
   this.post = null;
   this.object = object;
+  this.deletionLock = false;
+
   $.data(object[0], 'thread', this);
 }
 
@@ -126,13 +128,25 @@ Thread.prototype.report = function() {
 }
 
 Thread.prototype.delete = function() {
-  var api = new mw.Api();
-  api.get({
-    action: 'flowthread',
-    type: 'delete',
-    postid: this.post.id
-  });
-  this.object.remove();
+  // Implements a mechanism for delete confirmation
+  if (!this.deletionLock) {
+    this.deletionLock = true;
+    this.object.find('.comment-delete').first().text(mw.msg('flowthread-ui-delete-confirmation'));
+    // Set timer
+    setTimeout(function () {
+      this.deletionLock = false;
+      this.object.find('.comment-delete').first().text(mw.msg('flowthread-ui-delete'));
+    }, 5000);
+  } else {
+    var api = new mw.Api();
+    api.get({
+      action: 'flowthread',
+      type: 'delete',
+      postid: this.post.id
+    });
+    this.deletionLock = false;
+    this.object.remove();
+  }
 }
 
 Thread.prototype.markAsPopular = function() {

--- a/extension.json
+++ b/extension.json
@@ -89,6 +89,7 @@
 				"flowthread-ui-like",
 				"flowthread-ui-report",
 				"flowthread-ui-delete",
+				"flowthread-ui-delete_confirmation",
 				"flowthread-ui-usewikitext",
 				"flowthread-ui-preview",
 				"flowthread-ui-placeholder",
@@ -116,6 +117,7 @@
 				"flowthread-ui-like",
 				"flowthread-ui-report",
 				"flowthread-ui-delete",
+				"flowthread-ui-delete_confirmation",
 				"flowthread-ui-recover",
 				"flowthread-ui-markchecked",
 				"flowthread-ui-erase",
@@ -167,8 +169,8 @@
 	},
 	"config": {
 		"FlowThreadConfig": {
-			"Avatar": "http://www.gravatar.com/avatar/00000000000000000000000000000000?d=mm&f=y",
-			"AnonymousAvatar": "http://www.gravatar.com/avatar/00000000000000000000000000000000?d=mm&f=y",
+			"Avatar": "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mm&f=y",
+			"AnonymousAvatar": "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mm&f=y",
 			"PopularPostCount": 3,
 			"PopularPostThreshold": 1,
 			"MaxNestLevel": 3

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -33,6 +33,7 @@
 	"flowthread-ui-like": "Like",
 	"flowthread-ui-report": "Report",
 	"flowthread-ui-delete": "Delete",
+	"flowthread-ui-delete-confirmation": "Confirm deletion",
 	"flowthread-ui-recover": "Recover",
 	"flowthread-ui-markchecked": "Checked",
 	"flowthread-ui-erase": "Permantly Delete",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -33,7 +33,7 @@
 	"flowthread-ui-like": "Like",
 	"flowthread-ui-report": "Report",
 	"flowthread-ui-delete": "Delete",
-	"flowthread-ui-delete-confirmation": "Confirm deletion",
+	"flowthread-ui-delete_confirmation": "Confirm deletion",
 	"flowthread-ui-recover": "Recover",
 	"flowthread-ui-markchecked": "Checked",
 	"flowthread-ui-erase": "Permantly Delete",

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -33,6 +33,7 @@
 	"flowthread-ui-like": "赞",
 	"flowthread-ui-report": "举报",
 	"flowthread-ui-delete": "删除",
+	"flowthread-ui-delete-confirmation": "确认删除",
 	"flowthread-ui-recover": "恢复",
 	"flowthread-ui-markchecked": "已检查",
 	"flowthread-ui-erase": "永久删除",

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -33,7 +33,7 @@
 	"flowthread-ui-like": "赞",
 	"flowthread-ui-report": "举报",
 	"flowthread-ui-delete": "删除",
-	"flowthread-ui-delete-confirmation": "确认删除",
+	"flowthread-ui-delete_confirmation": "确认删除",
 	"flowthread-ui-recover": "恢复",
 	"flowthread-ui-markchecked": "已检查",
 	"flowthread-ui-erase": "永久删除",


### PR DESCRIPTION
Though I don't think it is essential, I add this feature as requested.

A few things to note:
- Only comments in **All comments** management section and **comments in pages** have this feature implemented and enabled. Permanent deletion will be performed without confirmation.
- Users should confirm their deletion requests in 1.5 seconds. If users don't respond in a timely manner, nothing will happen and comments will not be deleted. I think 1.5 seconds is enough for everyone.