### PR TITLE
Using ParserFactory to create parser instead of Parser::__construct()

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -1,6 +1,8 @@
 <?php
 namespace FlowThread;
 
+use MediaWiki\MediaWikiServices;
+
 class API extends \ApiBase {
 
 	private function dieNoParam($name) {
@@ -356,7 +358,7 @@ class API extends \ApiBase {
 					}
 				}
 
-				$parser = new \Parser();
+				$parser = MediaWikiServices::getInstance()->getParserFactory()->create();
 
 				// Set options for parsing
 				$opt = new \ParserOptions($this->getUser());


### PR DESCRIPTION
Use of Parser::__construct was deprecated in MediaWiki 1.34.
Note: This commit is break change for 1.32.