### PR TITLE
Fix 'Unique key array should be a list'

### DIFF
--- a/special/Control.php
+++ b/special/Control.php
@@ -220,7 +220,7 @@ class SpecialControl extends \FormSpecialPage {
 				'flowthread_ctrl_status' => $status,
 			];
 			$dbw->upsert('FlowThreadControl', $values, [
-				'flowthread_ctrl_pageid' => $id,
+				'flowthread_ctrl_pageid'
 			], $values);
 		}
 	}


### PR DESCRIPTION
The method `upsert` have been updated.
Due to the type of `$uniqueKeys` was changed to `string | string[] | string[][] `, we will get a `Wikimedia\Rdbms\DBUnexpectedError` from `$IP/includes/libs/rdbms/database/Database.php` when `upsert` was called with `$uniqueKeys` in a Key-Value form.