### PR TITLE
Some compatibility fix for newer MediaWiki version or MySQL

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -6,6 +6,9 @@
   "version": "1.3.2",
   "license-name": "BSD-2-Clause",
   "type": "specialpage",
+  "requires": {
+    "MediaWiki": ">= 1.38.0"
+  },
   "ExtensionMessagesFiles": {
     "FlowThreadAlias": "FlowThread.alias.php"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -90,6 +90,7 @@
   "flowthread-reply-anonymous": "@$1 ",
 
   "apihelp-flowthread-description": "FlowThread action API",
+  "apihelp-flowthread-summary": "FlowThread action API",
   "apihelp-flowthread-param-type": "Type of action to take. (Must be one of list, like, dislike, report, delete, recover, erase, markchecked or post)",
   "apihelp-flowthread-param-pageid": "ID of the page to comment on (type = post), or to list comment (type = list). Required when type is post and list.",
   "apihelp-flowthread-param-postid": "ID of the post to act on (type = like, dislike, report, delete, recover, erase, markchecked), or to reply (type = post). Required in the former case.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2,7 +2,7 @@
   "flowthread_desc": "This extension provides a thread-like commenting system",
   "log-name-comments": "Comments log",
   "log-description-comments": "This page shows administrative activities related to comments.",
-  "log-show-hide-comments": "Comment log",
+  "logeventslist-comments-log": "Comment log",
   "logentry-comments-delete": "$1 deleted a comment by $4 from $3.",
   "logentry-comments-recover": "$1 recovered a comment by $4 from $3.",
   "logentry-comments-erase": "$1 permantly deleted a comment by $4 from $3, along with its $5 follow-ups.",

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -87,6 +87,7 @@
   "flowthread-blacklist": "# 在这个列表中的文本会被禁止在评论中出现。\n# 语法如下：\n#* 任何由\"#\"字符开头至行尾的内容都算作注释\n#* 任何非空白行都是匹配文本的正则表达式片段\n #<!-- 请完整地保留此行 --><pre>\n\n #</pre><!-- 请完整地保留此行 -->",
 
   "apihelp-flowthread-description": "FlowThread操作API",
+  "apihelp-flowthread-summary": "FlowThread操作API",
   "apihelp-flowthread-param-type": "需要进行的操作。（必须为 list, like, dislike, report, delete, recover, erase, markchecked 或 post 其中一项）",
   "apihelp-flowthread-param-pageid": "要进行评论 (type = post)，或者要列举评论 (type = list) 的页面的ID。对于 post 和 list 操作来说是必须的。",
   "apihelp-flowthread-param-postid": "要进行操作 (type = like, dislike, report, delete, recover, erase, markchecked)，或者要回复 (type = post) 的评论的ID。在前一种情况下是必须的。",

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -2,7 +2,7 @@
   "flowthread_desc": "这个插件提供了类似论坛帖子的评论系统",
   "log-name-comments": "评论日志",
   "log-description-comments": "此页面显示评论管理的日志。",
-  "log-show-hide-comments": "$1评论日志",
+  "logeventslist-comments-log": "评论日志",
   "logentry-comments-delete": "$1从页面$3中删除了$4的评论",
   "logentry-comments-recover": "$1从页面$3中恢复了$4的评论",
   "logentry-comments-erase": "$1从页面$3中永久删除了$4的评论及$5条子评论",


### PR DESCRIPTION
Since there were a bunch of changes that break the compatibility with old versions (at least prior to 1.34), I assume that this extension only supports 1.34 and later.
You truly need to declare the required MediaWiki version.