### PR TITLE
Fix #67: Use count() instead of FOUND_ROWS() SQL function

### DIFF
--- a/includes/Query.php
+++ b/includes/Query.php
@@ -89,13 +89,11 @@ class Query {
 
 		if ($this->threadMode) {
 			$this->totalCount = $dbr->newSelectQueryBuilder()
-				->select('COUNT(*) as count')
+				->select('COUNT(*)')
 				->from('FlowThread')
 				->where($cond)
 				->caller(__METHOD__)
-				->fetchResultSet()
-				->fetchObject()
-				->count;
+				->fetchField();
 
 			// Recursively get all children post list
 			// This is not really resource consuming as you might think, as we use IN to boost it up

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -37,9 +37,6 @@ class Query {
 		if ($this->limit !== -1) {
 			$options['LIMIT'] = $this->limit;
 		}
-		if ($this->threadMode) {
-			$options[] = 'SQL_CALC_FOUND_ROWS';
-		}
 
 		$cond = [];
 		if ($this->pageid) {
@@ -91,7 +88,14 @@ class Query {
 		}
 
 		if ($this->threadMode) {
-			$this->totalCount = intval($dbr->query('select FOUND_ROWS() as row')->fetchObject()->row);
+			$this->totalCount = $dbr->newSelectQueryBuilder()
+				->select('COUNT(*) as count')
+				->from('FlowThread')
+				->where($cond)
+				->caller(__METHOD__)
+				->fetchResultSet()
+				->fetchObject()
+				->count;
 
 			// Recursively get all children post list
 			// This is not really resource consuming as you might think, as we use IN to boost it up


### PR DESCRIPTION
FOUND_ROWS() function are deprecated as of MySQL 8.0.17. So query will fail on affected mysql versions.

In this case, just use `COUNT(*)` to calculate the size of the result set.

[0] https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_found-rows