### PR TITLE
修复能点到隐藏的预览按钮

### DIFF
--- a/assets/common.css
+++ b/assets/common.css
@@ -123,6 +123,7 @@
     width: 0px;
     margin: 4px 0;
     opacity: 0;
+    visibility: hidden;
     background-image: url(preview.svg);
 }
 
@@ -134,6 +135,7 @@
     width: 24px;
     margin: 4px;
     opacity: 1;
+    visibility: visible;
 }
 
 .comment-reply::before, .comment-like::before, .comment-report::before, .comment-delete::before, .comment-recover::before {


### PR DESCRIPTION
目前是直接用opacity的方式隐藏，用户还是可以点击到被隐藏的按钮，此PR加上了visibility属性来控制是否能点击到