### PR TITLE
fix: Use ReadOnlyMode instead of wfReadOnly()

### DIFF
--- a/includes/Post.php
+++ b/includes/Post.php
@@ -159,7 +159,7 @@ class Post {
 			return false;
 		}
 		/* Prevent cross-site request forgeries */
-		if (wfReadOnly()) {
+		if (MediaWikiServices::getInstance()->getReadOnlyMode()->isReadOnly()) {
 			return false;
 		}
 		return true;
@@ -175,7 +175,7 @@ class Post {
 			throw new \Exception("Current user cannot post comment");
 		}
 		/* Prevent cross-site request forgeries */
-		if (wfReadOnly()) {
+		if (MediaWikiServices::getInstance()->getReadOnlyMode()->isReadOnly()) {
 			throw new \Exception("Site in readonly mode");
 		}
 	}


### PR DESCRIPTION
wfReadOnly() already deprecated since 1.38 and will be removed in 1.40.