### PR TITLE
Fix nbdd0121/MW-FlowThread#74 closing comment section bug

### DIFF
--- a/special/Control.php
+++ b/special/Control.php
@@ -223,7 +223,7 @@ class SpecialControl extends \FormSpecialPage {
 				'flowthread_ctrl_status' => $status,
 			];
 			$dbw->upsert('FlowThreadControl', $values, [
-				'flowthread_ctrl_pageid' => $id,
+				'flowthread_ctrl_pageid'
 			], $values);
 		}
 	}


### PR DESCRIPTION
Fixed the bug described in this issue. I tested it on MW 1.38. It no longer gives the error message and the comment section is successfully closed. 