### PR TITLE
Replace all deprecated api and fix compatible with MediaWiki 1.39

### DIFF
--- a/echo/Hooks.php
+++ b/echo/Hooks.php
@@ -1,6 +1,8 @@
 <?php
 namespace FlowThread;
 
+use MediaWiki\MediaWikiServices;
+
 class EchoHooks {
 
 	public static function onBeforeCreateEchoEvent(&$notifications, &$notificationCategories, &$icons) {
@@ -73,7 +75,7 @@ class EchoHooks {
 			}
 			$recipientId = $extra['target-user-id'];
 			foreach ($recipientId as $id) {
-				$recipient = \User::newFromId($id);
+				$recipient = MediaWikiServices::getInstance()->getUserFactory()->newFromId($id);
 				$users[$id] = $recipient;
 			}
 			break;
@@ -82,7 +84,7 @@ class EchoHooks {
 	}
 
 	public static function onFlowThreadPosted($post) {
-		$poster = \User::newFromId($post->userid);
+		$poster = MediaWikiServices::getInstance()->getUserFactory()->newFromId($post->userid);
 		$title = \Title::newFromId($post->pageid);
 
 		$targets = array();
@@ -110,7 +112,7 @@ class EchoHooks {
 
 		// Check if posted on a user page
 		if ($title->getNamespace() === NS_USER && !$title->isSubpage()) {
-			$user = \User::newFromName($title->getText());
+			$user = MediaWikiServices::getInstance()->getUserFactory()->newFromName($title->getText());
 			// If user exists and is not the poster
 			if ($user && $user->getId() !== 0 && !$user->equals($poster) && !in_array($user->getId(), $targets)) {
 				\EchoEvent::create(array(
@@ -133,7 +135,7 @@ class EchoHooks {
 			return true;
 		}
 
-		$poster = \User::newFromId($post->userid);
+		$poster = MediaWikiServices::getInstance()->getUserFactory()->newFromId($post->userid);
 		$title = \Title::newFromId($post->pageid);
 
 		\EchoEvent::create(array(
@@ -153,7 +155,7 @@ class EchoHooks {
 			return true;
 		}
 
-		$poster = \User::newFromId($post->userid);
+		$poster = MediaWikiServices::getInstance()->getUserFactory()->newFromId($post->userid);
 		$title = \Title::newFromId($post->pageid);
 
 		\EchoEvent::create(array(
@@ -173,7 +175,7 @@ class EchoHooks {
 			return true;
 		}
 
-		$poster = \User::newFromId($post->userid);
+		$poster = MediaWikiServices::getInstance()->getUserFactory()->newFromId($post->userid);
 		$title = \Title::newFromId($post->pageid);
 
 		\EchoEvent::create(array(
@@ -194,7 +196,7 @@ class EchoHooks {
 			$targets[] = $id;
 		}
 
-		$poster = \User::newFromId($post->userid);
+		$poster = MediaWikiServices::getInstance()->getUserFactory()->newFromId($post->userid);
 		$title = \Title::newFromId($post->pageid);
 
 		\EchoEvent::create(array(

--- a/includes/API.php
+++ b/includes/API.php
@@ -2,6 +2,7 @@
 namespace FlowThread;
 
 use MediaWiki\MediaWikiServices;
+use Wikimedia\ParamValidator\ParamValidator;
 
 class API extends \ApiBase {
 
@@ -423,26 +424,26 @@ class API extends \ApiBase {
 	public function getAllowedParams() {
 		return array(
 			'type' => array(
-				\ApiBase::PARAM_TYPE => 'string',
-				\ApiBase::PARAM_REQUIRED => true,
+				ParamValidator::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_REQUIRED => true,
 			),
 			'pageid' => array(
-				\ApiBase::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_TYPE => 'integer',
 			),
 			'postid' => array(
-				\ApiBase::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_TYPE => 'string',
 			),
 			'content' => array(
-				\ApiBase::PARAM_TYPE => 'string',
+                ParamValidator::PARAM_TYPE => 'string',
 			),
 			'wikitext' => array(
-				\ApiBase::PARAM_TYPE => 'boolean',
+                ParamValidator::PARAM_TYPE => 'boolean',
 			),
 			'offset' => array(
-				\ApiBase::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_TYPE => 'integer',
 			),
 			'limit' => array(
-				\ApiBase::PARAM_TYPE => 'integer',
+                ParamValidator::PARAM_TYPE => 'integer',
 			),
 		);
 	}

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -1,6 +1,7 @@
 <?php
 namespace FlowThread;
 
+use MediaWiki\MediaWikiServices;
 use Wikimedia\Rdbms\DBConnRef;
 
 class Helper {
@@ -41,7 +42,7 @@ class Helper {
 
 		if ( !count($needed) ) return 0;
 
-		$dbr = wfGetDB(DB_REPLICA);
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
 		$inExpr = self::buildSQLInExpr($dbr, $ids);
 		$res = $dbr->select('FlowThread', Post::getRequiredColumns(), [
 			'flowthread_id' . $inExpr
@@ -83,7 +84,7 @@ class Helper {
 			return $ret;
 		}
 
-		$dbr = wfGetDB(DB_REPLICA);
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
 
 		$inExpr = self::buildPostInExpr($dbr, $posts);
 		$res = $dbr->select('FlowThreadAttitude', array(
@@ -112,7 +113,7 @@ class Helper {
 		$links = $output->getLinks();
 		if (isset($links[NS_USER]) && is_array($links[NS_USER])) {
 			foreach ($links[NS_USER] as $titleName => $pageId) {
-				$user = \User::newFromName($titleName);
+				$user = MediaWikiServices::getInstance()->getUserFactory()->newFromName($titleName);
 				if (!$user) {
 					continue; // Invalid user
 				}

--- a/includes/PopularPosts.php
+++ b/includes/PopularPosts.php
@@ -50,7 +50,7 @@ class PopularPosts {
 		if (!$wgFlowThreadConfig['PopularPostCount']) {
 			return array();
 		}
-		$dbr = wfGetDB(DB_REPLICA);
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
 		$cond = array(
 			'flowthread_pageid' => $pageid,
 			'flowthread_status' => Post::STATUS_NORMAL,

--- a/includes/Post.php
+++ b/includes/Post.php
@@ -87,7 +87,7 @@ class Post {
 
 	public static function newFromId(UID $id) {
 		// Do not apply cache here, it will seriously slow down the application
-		$dbr = wfGetDB(DB_REPLICA);
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
 
 		$row = $dbr->selectRow('FlowThread',
 			self::getRequiredColumns(),
@@ -111,7 +111,7 @@ class Post {
 	/**
 	 * Check if the user can perform basic administration action
 	 *
-	 * @param User $user
+	 * @param \User $user
 	 *   User who is acting the action
 	 * @return
 	 *   True if the user can performe admin
@@ -135,9 +135,9 @@ class Post {
 	/**
 	 * Check if the a page is one's user page or user subpage
 	 *
-	 * @param User $user
+	 * @param \User $user
 	 *   User who is acting the action
-	 * @param Title $title
+	 * @param \Title $title
 	 *   Page on which the action is acting
 	 * @return
 	 *   True if the page belongs to the user
@@ -159,7 +159,7 @@ class Post {
 			return false;
 		}
 		/* Prevent cross-site request forgeries */
-		if (wfReadOnly()) {
+		if (MediaWikiServices::getInstance()->getReadOnlyMode()->isReadOnly()) {
 			return false;
 		}
 		return true;
@@ -175,7 +175,7 @@ class Post {
 			throw new \Exception("Current user cannot post comment");
 		}
 		/* Prevent cross-site request forgeries */
-		if (wfReadOnly()) {
+		if (MediaWikiServices::getInstance()->getReadOnlyMode()->isReadOnly()) {
 			throw new \Exception("Site in readonly mode");
 		}
 	}
@@ -199,7 +199,7 @@ class Post {
 	}
 
 	private function switchStatus($newStatus) {
-		$dbw = wfGetDB(DB_MASTER);
+		$dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_PRIMARY);
 		$dbw->update('FlowThread', array(
 			'flowthread_status' => $newStatus,
 		), array(
@@ -241,7 +241,7 @@ class Post {
 		$this->reportCount = 0;
 		$this->updateFavorReportCount();
 
-		$db = wfGetDB(DB_MASTER);
+		$db = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_PRIMARY);
 		$db->delete('FlowThreadAttitude', array(
 			'flowthread_att_id' => $this->id->getBin(),
 			'flowthread_att_type' => self::ATTITUDE_REPORT,
@@ -306,7 +306,7 @@ class Post {
 			throw new \Exception("Post must be deleted first before erasing");
 		}
 
-		$dbw = wfGetDB(DB_MASTER);
+		$dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_PRIMARY);
 		$counter = $this->eraseSilently($dbw);
 
 		// Add to log
@@ -324,7 +324,7 @@ class Post {
 	}
 
 	public function post() {
-		$dbw = wfGetDB(DB_MASTER);
+		$dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_PRIMARY);
 		if (!$this->id) {
 			$this->id = UID::generate();
 		}
@@ -407,7 +407,7 @@ class Post {
 	public function getChildren() {
 		$this->validate();
 
-		$dbr = wfGetDB(DB_REPLICA);
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
 
 		$res = $dbr->select('FlowThread',
 			self::getRequiredColumns(), array(
@@ -434,7 +434,7 @@ class Post {
 	}
 
 	public function getUserAttitude(\User $user) {
-		$dbr = wfGetDB(DB_REPLICA);
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
 		$row = $dbr->selectRow('FlowThreadAttitude', 'flowthread_att_type', array(
 			'flowthread_att_id' => $this->id->getBin(),
 			'flowthread_att_userid' => $user->getId(),
@@ -447,7 +447,7 @@ class Post {
 	}
 
 	private function updateFavorReportCount() {
-		$dbw = wfGetDB(DB_MASTER);
+		$dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_PRIMARY);
 		$dbw->update('FlowThread', array(
 			'flowthread_like' => $this->favorCount,
 			'flowthread_report' => $this->reportCount,
@@ -459,7 +459,7 @@ class Post {
 	public function setUserAttitude(\User $user, $att) {
 		self::checkIfCanVote($user);
 
-		$dbw = wfGetDB(DB_MASTER);
+		$dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_PRIMARY);
 
 		// Get current attitude
 		$oldatt = $this->getUserAttitude($user);

--- a/includes/Query.php
+++ b/includes/Query.php
@@ -1,6 +1,8 @@
 <?php
 namespace FlowThread;
 
+use MediaWiki\MediaWikiServices;
+
 class Query {
 	const FILTER_ALL = 0;
 	const FILTER_NORMAL = 1;
@@ -23,7 +25,7 @@ class Query {
 	public $posts = null;
 
 	public function fetch() {
-		$dbr = wfGetDB(DB_REPLICA);
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
 
 		$comments = array();
 		$parentLookup = array();
@@ -136,7 +138,7 @@ class Query {
 		global $wgTriggerFlowThreadHooks;
 		$wgTriggerFlowThreadHooks = false;
 
-		$dbw = wfGetDB(DB_MASTER);
+		$dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_PRIMARY);
 		foreach ($this->posts as $post) {
 			if ($post->isValid()) {
 				$post->eraseSilently($dbw);

--- a/special/Control.php
+++ b/special/Control.php
@@ -105,7 +105,7 @@ class SpecialControl extends \FormSpecialPage {
 	}
 
 	protected function alterForm( \HTMLForm $form ) {
-		$form->setHeaderText('');
+		$form->setHeaderHtml('');
 		if ($this->currentStatus === self::STATUS_ENABLED) {
 			$form->setSubmitDestructive();
 			$form->setSubmitTextMsg( $this->ownsPage ? 'flowthreadcontrol-optout' : 'flowthreadcontrol-disable' );
@@ -201,7 +201,7 @@ class SpecialControl extends \FormSpecialPage {
 	public static function getControlStatus(\Title $title) {
 		$id = $title->getArticleID();
 
-		$dbr = wfGetDB(DB_REPLICA);
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
 		$row = $dbr->selectRow('FlowThreadControl', ['flowthread_ctrl_status'], [
 			'flowthread_ctrl_pageid' => $title->getArticleID(),
 		]);
@@ -212,7 +212,7 @@ class SpecialControl extends \FormSpecialPage {
 
 	public static function setControlStatus(\Title $title, $status) {
 		$id = $title->getArticleID();
-		$dbw = wfGetDB(DB_MASTER);
+		$dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_PRIMARY);
 		if ($status === self::STATUS_ENABLED) {
 			$dbw->delete('FlowThreadControl', [
 				'flowthread_ctrl_pageid' => $id,

--- a/special/Export.php
+++ b/special/Export.php
@@ -2,6 +2,8 @@
 
 namespace FlowThread;
 
+use MediaWiki\MediaWikiServices;
+
 class SpecialExport extends \SpecialPage {
 
 	public function __construct() {
@@ -39,7 +41,7 @@ class SpecialExport extends \SpecialPage {
 			$request->response()->header("Cache-Control: no-cache");
 
 			// Got all data. NOTE that ORDER BY is essential since we are grouping comments
-			$dbr = wfGetDB(DB_REPLICA);
+			$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
 
 			$pageid = 0;
 			$counter = 0;

--- a/special/Import.php
+++ b/special/Import.php
@@ -53,6 +53,8 @@ class SpecialImport extends \FormSpecialPage {
 		}
 
 		$this->doImport($data->getValue());
+
+        return \Status::newGood();
 	}
 
 	private function doImport(array $json) {

--- a/special/Link.php
+++ b/special/Link.php
@@ -1,6 +1,8 @@
 <?php
 namespace FlowThread;
 
+use MediaWiki\MediaWikiServices;
+
 class SpecialLink extends \RedirectSpecialPage {
 
 	private $query = array();
@@ -17,7 +19,7 @@ class SpecialLink extends \RedirectSpecialPage {
 					$post = $post->getParent();
 				}
 
-				$db = wfGetDB(DB_REPLICA);
+				$db = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
 
 				$cond = array(
 					'flowthread_pageid' => $post->pageid,


### PR DESCRIPTION
1. Use ```UserFactory``` to fetch user object
2. Use ```ParamValidator``` for api parameter definition
3. Use ```DBLoadBalancer``` to get database instance