### PR TITLE
fix: Using class declarations with namespace

### DIFF
--- a/echo/Hooks.php
+++ b/echo/Hooks.php
@@ -1,7 +1,10 @@
 <?php
 namespace FlowThread;
 
+use MediaWiki\Extension\Notifications\Model\Event;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 
 class EchoHooks {
 
@@ -85,7 +88,7 @@ class EchoHooks {
 
 	public static function onFlowThreadPosted($post) {
 		$poster = MediaWikiServices::getInstance()->getUserFactory()->newFromId($post->userid);
-		$title = \Title::newFromId($post->pageid);
+		$title = Title::newFromId($post->pageid);
 
 		$targets = array();
 		$parent = $post->getParent();
@@ -100,7 +103,7 @@ class EchoHooks {
 			}
 			$targets[] = $parent->userid;
 		}
-		\EchoEvent::create(array(
+		EchoEvent::create(array(
 			'type' => 'flowthread_reply',
 			'title' => $title,
 			'extra' => array(
@@ -115,7 +118,7 @@ class EchoHooks {
 			$user = MediaWikiServices::getInstance()->getUserFactory()->newFromName($title->getText());
 			// If user exists and is not the poster
 			if ($user && $user->getId() !== 0 && !$user->equals($poster) && !in_array($user->getId(), $targets)) {
-				\EchoEvent::create(array(
+				Event::create(array(
 					'type' => 'flowthread_userpage',
 					'title' => $title,
 					'extra' => array(
@@ -130,15 +133,15 @@ class EchoHooks {
 		return true;
 	}
 
-	public static function onFlowThreadDeleted($post, \User $initiator) {
+	public static function onFlowThreadDeleted($post, User $initiator) {
 		if ($post->userid === 0 || $post->userid === $initiator->getId()) {
 			return true;
 		}
 
 		$poster = MediaWikiServices::getInstance()->getUserFactory()->newFromId($post->userid);
-		$title = \Title::newFromId($post->pageid);
+		$title = Title::newFromId($post->pageid);
 
-		\EchoEvent::create(array(
+		Event::create(array(
 			'type' => 'flowthread_delete',
 			'title' => $title,
 			'extra' => array(
@@ -150,15 +153,15 @@ class EchoHooks {
 		return true;
 	}
 
-	public static function onFlowThreadRecovered($post, \User $initiator) {
+	public static function onFlowThreadRecovered($post, User $initiator) {
 		if ($post->userid === 0 || $post->userid === $initiator->getId()) {
 			return true;
 		}
 
 		$poster = MediaWikiServices::getInstance()->getUserFactory()->newFromId($post->userid);
-		$title = \Title::newFromId($post->pageid);
+		$title = Title::newFromId($post->pageid);
 
-		\EchoEvent::create(array(
+		Event::create(array(
 			'type' => 'flowthread_recover',
 			'title' => $title,
 			'extra' => array(
@@ -176,9 +179,9 @@ class EchoHooks {
 		}
 
 		$poster = MediaWikiServices::getInstance()->getUserFactory()->newFromId($post->userid);
-		$title = \Title::newFromId($post->pageid);
+		$title = Title::newFromId($post->pageid);
 
-		\EchoEvent::create(array(
+		Event::create(array(
 			'type' => 'flowthread_spam',
 			'title' => $title,
 			'extra' => array(
@@ -197,9 +200,9 @@ class EchoHooks {
 		}
 
 		$poster = MediaWikiServices::getInstance()->getUserFactory()->newFromId($post->userid);
-		$title = \Title::newFromId($post->pageid);
+		$title = Title::newFromId($post->pageid);
 
-		\EchoEvent::create(array(
+		Event::create(array(
 			'type' => 'flowthread_mention',
 			'title' => $title,
 			'extra' => array(

--- a/echo/PresentationModel.php
+++ b/echo/PresentationModel.php
@@ -1,7 +1,11 @@
 <?php
 namespace FlowThread;
 
-class EchoPresentationModel extends \EchoEventPresentationModel {
+use Exception;
+use MediaWiki\Extension\Notifications\Formatters\EchoEventPresentationModel;
+use MediaWiki\SpecialPage\SpecialPage;
+
+class EchoPresentationModel extends EchoEventPresentationModel {
 
 	protected $post = false;
 
@@ -9,7 +13,7 @@ class EchoPresentationModel extends \EchoEventPresentationModel {
 		if ($this->post === false) {
 			try {
 				$this->post = Post::newFromId(UID::fromBin($this->event->getExtraParam('postid')));
-			} catch (\Exception $e) {
+			} catch (Exception $e) {
 				$this->post = null;
 			}
 		}
@@ -66,7 +70,7 @@ class EchoPresentationModel extends \EchoEventPresentationModel {
 				$msg = $this->msg('notification-link-text-view-flowthread-post');
 			}
 			return [
-				'url' => \SpecialPage::getTitleFor('FlowThreadLink', $this->post->id->getHex())->getLocalURL(),
+				'url' => SpecialPage::getTitleFor('FlowThreadLink', $this->post->id->getHex())->getLocalURL(),
 				'label' => $msg->text(),
 			];
 		} else {

--- a/includes/Helper.php
+++ b/includes/Helper.php
@@ -2,6 +2,9 @@
 namespace FlowThread;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use Wikimedia\Rdbms\DBConnRef;
 
 class Helper {
@@ -69,7 +72,7 @@ class Helper {
 		return count($needed);
 	}
 
-	public static function batchGetUserAttitude(\User $user, array $posts) {
+	public static function batchGetUserAttitude(User $user, array $posts) {
 		if (!count($posts)) {
 			return array();
 		}
@@ -108,7 +111,7 @@ class Helper {
 	}
 
 	public static function generateMentionedList(\ParserOutput $output, Post $post) {
-		$pageTitle = \Title::newFromId($post->pageid);
+		$pageTitle = Title::newFromId($post->pageid);
 		$mentioned = array();
 		$links = $output->getLinks();
 		if (isset($links[NS_USER]) && is_array($links[NS_USER])) {
@@ -154,7 +157,7 @@ class Helper {
 		return $ret;
 	}
 
-	public static function canEverPostOnTitle(\Title $title) {
+	public static function canEverPostOnTitle(Title $title) {
 		// Disallow commenting on pages without article id
 		if ($title->getArticleID() == 0) {
 			return false;

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -1,12 +1,21 @@
 <?php
 namespace FlowThread;
 
+use Exception;
+use MediaWiki\Content\Content;
+use MediaWiki\Logging\LogEntry;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Output\OutputPage;
 use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\Skin\BaseTemplate;
+use MediaWiki\Skin\Skin;
+use MediaWiki\Skin\SkinTemplate;
+use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\User\User;
 
 class Hooks {
 
-	public static function onBeforePageDisplay(\OutputPage &$output, \Skin &$skin) {
+	public static function onBeforePageDisplay(OutputPage &$output, Skin &$skin) {
 		$title = $output->getTitle();
 
 		// If the comments are never allowed on the title, do not load
@@ -36,7 +45,7 @@ class Hooks {
 		);
 
 		// First check if user can post at all
-		if (!\FlowThread\Post::canPost($output->getUser())) {
+		if (!Post::canPost($output->getUser())) {
 			$config['CantPostNotice'] = wfMessage('flowthread-ui-cantpost')->parse();
 		} else {
 			$status = SpecialControl::getControlStatus($title);
@@ -61,7 +70,7 @@ class Hooks {
 		$dbType = $updater->getDB()->getType();
 		// For non-MySQL/MariaDB/SQLite DBMSes, use the appropriately named file
 		if (!in_array($dbType, array('mysql', 'sqlite'))) {
-			throw new \Exception('Database type not currently supported');
+			throw new Exception('Database type not currently supported');
 		} else {
 			$filename = 'mysql.sql';
 		}
@@ -73,7 +82,7 @@ class Hooks {
 		return true;
 	}
 
-	public static function onArticleDeleteComplete(&$article, \User &$user, $reason, $id, \Content $content = null, \LogEntry $logEntry) {
+	public static function onArticleDeleteComplete(&$article, User &$user, $reason, $id, Content $content = null, LogEntry $logEntry) {
 		$page = new Query();
 		$page->pageid = $id;
 		$page->limit = -1;
@@ -83,7 +92,7 @@ class Hooks {
 		return true;
 	}
 
-	public static function onBaseTemplateToolbox(\BaseTemplate &$baseTemplate, array &$toolbox) {
+	public static function onBaseTemplateToolbox(BaseTemplate &$baseTemplate, array &$toolbox) {
 		if (isset($baseTemplate->data['nav_urls']['usercomments'])
 			&& $baseTemplate->data['nav_urls']['usercomments']) {
 			$toolbox['usercomments'] = $baseTemplate->data['nav_urls']['usercomments'];
@@ -91,21 +100,21 @@ class Hooks {
 		}
 	}
 
-	public static function onSidebarBeforeOutput(\Skin $skin, &$sidebar) {
+	public static function onSidebarBeforeOutput(Skin $skin, &$sidebar) {
 		$commentAdmin = self::getPermissionManager()->userHasRight($skin->getUser(), 'commentadmin-restricted');
 		$user = $skin->getRelevantUser();
 
 		if ($user && $commentAdmin) {
 			$sidebar['TOOLBOX'][] = [
 				'text' => wfMessage('sidebar-usercomments')->text(),
-				'href' => \SpecialPage::getTitleFor('FlowThreadManage')->getLocalURL(array(
+				'href' => SpecialPage::getTitleFor('FlowThreadManage')->getLocalURL(array(
 					'user' => $user->getName(),
 				)),
 			];
 		}
 	}
 
-	public static function onSkinTemplateNavigation_Universal(\SkinTemplate $skinTemplate, array &$links) {
+	public static function onSkinTemplateNavigation_Universal(SkinTemplate $skinTemplate, array &$links) {
 		$commentAdmin = self::getPermissionManager()->userHasRight($skinTemplate->getUser(), 'commentadmin-restricted');
 		$user = $skinTemplate->getRelevantUser();
 
@@ -115,7 +124,7 @@ class Hooks {
 			$links['actions']['flowthreadcontrol'] = [
 				'id' => 'ca-flowthreadcontrol',
 				'text' => wfMessage('action-flowthreadcontrol')->text(),
-				'href' => \SpecialPage::getTitleFor('FlowThreadControl', $title->getPrefixedDBKey())->getLocalURL()
+				'href' => SpecialPage::getTitleFor('FlowThreadControl', $title->getPrefixedDBKey())->getLocalURL()
 			];
 		}
 

--- a/includes/Post.php
+++ b/includes/Post.php
@@ -1,8 +1,13 @@
 <?php
 namespace FlowThread;
 
+use Exception;
+use MediaWiki\Logging\ManualLogEntry;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
+use stdClass;
 use Wikimedia\Rdbms\DBConnRef;
 
 class Post {
@@ -61,7 +66,7 @@ class Post {
 		);
 	}
 
-	public static function newFromDatabaseRow(\stdClass $row) {
+	public static function newFromDatabaseRow(stdClass $row) {
 		$id = UID::fromBin($row->flowthread_id);
 
 		// This is either NULL or a binary UID
@@ -95,7 +100,7 @@ class Post {
 		);
 
 		if ($row === false) {
-			throw new \Exception("Invalid post id");
+			throw new Exception("Invalid post id");
 		}
 
 		return self::newFromDatabaseRow($row);
@@ -105,51 +110,51 @@ class Post {
 	 * Terminate the API execution for permission reason
 	 */
 	private static function diePermission() {
-		throw new \Exception("Current user cannot perform comment the specified administration action");
+		throw new Exception("Current user cannot perform comment the specified administration action");
 	}
 
 	/**
 	 * Check if the user can perform basic administration action
 	 *
-	 * @param \User $user
+	 * @param User $user
 	 *   User who is acting the action
 	 * @return
 	 *   True if the user can performe admin
 	 */
-	private static function canPerformAdmin(\User $user) {
+	private static function canPerformAdmin(User $user) {
 		return self::getPermissionManager()->userHasRight($user, 'commentadmin-restricted');
 	}
 
-	private static function checkIfAdmin(\User $user) {
+	private static function checkIfAdmin(User $user) {
 		if (!self::getPermissionManager()->userHasRight($user, 'commentadmin-restricted')) {
-			throw new \Exception("Current user cannot perform comment admin");
+			throw new Exception("Current user cannot perform comment admin");
 		}
 	}
 
-	private static function checkIfAdminFull(\User $user) {
+	private static function checkIfAdminFull(User $user) {
 		if (!self::getPermissionManager()->userHasRight($user, 'commentadmin')) {
-			throw new \Exception("Current user cannot perform full comment admin");
+			throw new Exception("Current user cannot perform full comment admin");
 		}
 	}
 
 	/**
 	 * Check if the a page is one's user page or user subpage
 	 *
-	 * @param \User $user
+	 * @param User $user
 	 *   User who is acting the action
-	 * @param \Title $title
+	 * @param Title $title
 	 *   Page on which the action is acting
 	 * @return
 	 *   True if the page belongs to the user
 	 */
-	public static function userOwnsPage(\User $user, \Title $title) {
+	public static function userOwnsPage(User $user, Title $title) {
 		if ($title->getNamespace() === NS_USER && $title->getRootText() === $user->getName()) {
 			return true;
 		}
 		return false;
 	}
 
-	public static function canPost(\User $user) {
+	public static function canPost(User $user) {
 		/* Disallow blocked user to post */
 		if ($user->getBlock()) {
 			return false;
@@ -165,32 +170,32 @@ class Post {
 		return true;
 	}
 
-	public static function checkIfCanPost(\User $user) {
+	public static function checkIfCanPost(User $user) {
 		/* Disallow blocked user to post */
 		if ($user->getBlock()) {
-			throw new \Exception('User blocked');
+			throw new Exception('User blocked');
 		}
 		/* User without comment right cannot post */
 		if (!self::getPermissionManager()->userHasRight($user, 'comment')) {
-			throw new \Exception("Current user cannot post comment");
+			throw new Exception("Current user cannot post comment");
 		}
 		/* Prevent cross-site request forgeries */
 		if (MediaWikiServices::getInstance()->getReadOnlyMode()->isReadOnly()) {
-			throw new \Exception("Site in readonly mode");
+			throw new Exception("Site in readonly mode");
 		}
 	}
 
-	private static function checkIfCanVote(\User $user) {
+	private static function checkIfCanVote(User $user) {
 		self::checkIfCanPost($user);
 		if ($user->getId() == 0) {
-			throw new \Exception("Must login first");
+			throw new Exception("Must login first");
 		}
 	}
 
-	private function publishSimpleLog($subtype, \User $initiator) {
-		$logEntry = new \ManualLogEntry('comments', $subtype);
+	private function publishSimpleLog($subtype, User $initiator) {
+		$logEntry = new ManualLogEntry('comments', $subtype);
 		$logEntry->setPerformer($initiator);
-		$logEntry->setTarget(\Title::newFromId($this->pageid));
+		$logEntry->setTarget(Title::newFromId($this->pageid));
 		$logEntry->setParameters(array(
 			'4::username' => $this->username,
 		));
@@ -207,12 +212,12 @@ class Post {
 		));
 	}
 
-	public function recover(\User $user) {
+	public function recover(User $user) {
 		self::checkIfAdmin($user);
 
 		// Recover is invalid for a not-deleted post
 		if (!$this->isDeleted()) {
-			throw new \Exception("Post is not deleted");
+			throw new Exception("Post is not deleted");
 		}
 
 		// Mark status as normal
@@ -227,12 +232,12 @@ class Post {
 		}
 	}
 
-	public function markchecked(\User $user) {
+	public function markchecked(User $user) {
 		self::checkIfAdminFull($user);
 
 		// Mark-as-checked is invalid for a deleted post
 		if ($this->isDeleted()) {
-			throw new \Exception("Post is deleted");
+			throw new Exception("Post is deleted");
 		}
 
 		// Write a log
@@ -248,18 +253,18 @@ class Post {
 		));
 	}
 
-	public function delete(\User $user) {
+	public function delete(User $user) {
 		// Poster himself can delete as well
 		if ($user->getId() === 0 || $user->getId() !== $this->userid) {
 			if (!self::canPerformAdmin($user) &&
-				!self::userOwnsPage($user, \Title::newFromId($this->pageid))) {
+				!self::userOwnsPage($user, Title::newFromId($this->pageid))) {
 				self::diePermission();
 			}
 		}
 
 		// Delete is not valid for deleted post
 		if ($this->isDeleted()) {
-			throw new \Exception("Post is already deleted");
+			throw new Exception("Post is already deleted");
 		}
 
 		PopularPosts::invalidateCache($this);
@@ -298,21 +303,21 @@ class Post {
 		return $counter;
 	}
 
-	public function erase(\User $user) {
+	public function erase(User $user) {
 		self::checkIfAdminFull($user);
 
 		// To avoid mis-operation, a comment must be deleted (hidden from user) first before it is erased from database
 		if (!$this->isDeleted()) {
-			throw new \Exception("Post must be deleted first before erasing");
+			throw new Exception("Post must be deleted first before erasing");
 		}
 
 		$dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_PRIMARY);
 		$counter = $this->eraseSilently($dbw);
 
 		// Add to log
-		$logEntry = new \ManualLogEntry('comments', 'erase');
+		$logEntry = new ManualLogEntry('comments', 'erase');
 		$logEntry->setPerformer($user);
-		$logEntry->setTarget(\Title::newFromId($this->pageid));
+		$logEntry->setTarget(Title::newFromId($this->pageid));
 		$logEntry->setParameters(array(
 			'4::postid' => $this->username,
 			'5::children' => $counter - 1,
@@ -376,7 +381,7 @@ class Post {
 
 	public function validate() {
 		if (!$this->isValid()) {
-			throw new \Exception("Invalid post");
+			throw new Exception("Invalid post");
 		}
 	}
 
@@ -433,7 +438,7 @@ class Post {
 		return $this->reportCount;
 	}
 
-	public function getUserAttitude(\User $user) {
+	public function getUserAttitude(User $user) {
 		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
 		$row = $dbr->selectRow('FlowThreadAttitude', 'flowthread_att_type', array(
 			'flowthread_att_id' => $this->id->getBin(),
@@ -456,7 +461,7 @@ class Post {
 		));
 	}
 
-	public function setUserAttitude(\User $user, $att) {
+	public function setUserAttitude(User $user, $att) {
 		self::checkIfCanVote($user);
 
 		$dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_PRIMARY);

--- a/special/Control.php
+++ b/special/Control.php
@@ -1,9 +1,18 @@
 <?php
 namespace FlowThread;
 
+use MediaWiki\CommentStore\CommentStore;
+use MediaWiki\Exception\ErrorPageError;
+use MediaWiki\Exception\PermissionsError;
+use MediaWiki\Html\Html;
+use MediaWiki\HTMLForm\HTMLForm;
+use MediaWiki\Logging\LogEventsList;
+use MediaWiki\Logging\ManualLogEntry;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\SpecialPage\FormSpecialPage;
+use MediaWiki\Title\Title;
 
-class SpecialControl extends \FormSpecialPage {
+class SpecialControl extends FormSpecialPage {
 
 	const STATUS_ENABLED = 0;
 	const STATUS_OPTEDOUT = 1;
@@ -32,19 +41,19 @@ class SpecialControl extends \FormSpecialPage {
 	}
 
 	protected function setParameter( $par ) {
-		$title = \Title::newFromText( $par );
+		$title = Title::newFromText( $par );
 		$this->title = $title;
 
 		if ( !$title ) {
-			throw new \ErrorPageError( 'notargettitle', 'notargettext' );
+			throw new ErrorPageError( 'notargettitle', 'notargettext' );
 		}
 		if ( !$title->exists() ) {
-			throw new \ErrorPageError( 'nopagetitle', 'nopagetext' );
+			throw new ErrorPageError( 'nopagetitle', 'nopagetext' );
 		}
 
 		if ( !Helper::canEverPostOnTitle($title) ) {
 			// XXX: Should be some different text, but I'm lazy
-			throw new \ErrorPageError( 'notargettitle', 'notargettext' );
+			throw new ErrorPageError( 'notargettitle', 'notargettext' );
 		}
 
 		$status = self::getControlStatus($title);
@@ -59,7 +68,7 @@ class SpecialControl extends \FormSpecialPage {
 		// Access granted only if: is comment admin, or the user owns the page and the page is not disabled
 		// by admin.
 		if (!$isAdmin && (!$ownsPage || $status === self::STATUS_DISABLED)) {
-			throw new \PermissionsError('commentadmin');
+			throw new PermissionsError('commentadmin');
 		}
 	}
 
@@ -69,7 +78,7 @@ class SpecialControl extends \FormSpecialPage {
 		if ($this->currentStatus === self::STATUS_ENABLED) {
 			$fields['Reason'] = [
 				'type' => 'selectandother',
-				'maxlength' => \CommentStore::COMMENT_CHARACTER_LIMIT,
+				'maxlength' => CommentStore::COMMENT_CHARACTER_LIMIT,
 				'maxlength-unit' => 'codepoints',
 				'options-message' => 'flowthreadcontrol-disable-reason-dropdown',
 				'label-message' => 'flowthreadcontrol-disable-reason',
@@ -90,7 +99,7 @@ class SpecialControl extends \FormSpecialPage {
 		} else {
 			$fields['Reason'] = [
 				'type' => 'text',
-				'maxlength' => \CommentStore::COMMENT_CHARACTER_LIMIT,
+				'maxlength' => CommentStore::COMMENT_CHARACTER_LIMIT,
 				'maxlength-unit' => 'codepoints',
 				'label-message' => 'flowthreadcontrol-enable-reason',
 			];
@@ -104,7 +113,7 @@ class SpecialControl extends \FormSpecialPage {
 		return $fields;
 	}
 
-	protected function alterForm( \HTMLForm $form ) {
+	protected function alterForm( HTMLForm $form ) {
 		$form->setHeaderHtml('');
 		if ($this->currentStatus === self::STATUS_ENABLED) {
 			$form->setSubmitDestructive();
@@ -114,7 +123,7 @@ class SpecialControl extends \FormSpecialPage {
 		}
 	}
 
-	public function onSubmit(array $data, \HTMLForm $form = null ) {
+	public function onSubmit(array $data, HTMLForm $form = null ) {
 		$hiddenStatus = intval($data['CurrentStatus']);
 		if ($this->currentStatus !== $hiddenStatus) {
 			$this->currentStatus = $hiddenStatus;
@@ -139,7 +148,7 @@ class SpecialControl extends \FormSpecialPage {
 		if (isset($reason[0])){
 			$reason = $reason[0];
 		}
-		$logEntry = new \ManualLogEntry('comments', $disable ? 'disable' : 'enable');
+		$logEntry = new ManualLogEntry('comments', $disable ? 'disable' : 'enable');
 		$logEntry->setPerformer($performer);
 		$logEntry->setTarget($this->title);
 		$logEntry->setComment($reason);
@@ -176,7 +185,7 @@ class SpecialControl extends \FormSpecialPage {
 			);
 		}
 
-		$text = \Html::rawElement(
+		$text = Html::rawElement(
 			'p',
 			[ 'class' => 'mw-protect-editreasons' ],
 			$this->getLanguage()->pipeList( $links )
@@ -184,7 +193,7 @@ class SpecialControl extends \FormSpecialPage {
 
 		# Get relevant extracts from the block and suppression logs, if possible
 		$out = '';
-		\LogEventsList::showLogExtract(
+		LogEventsList::showLogExtract(
 			$out,
 			'comments',
 			$this->title->getPrefixedDBKey(),
@@ -198,7 +207,7 @@ class SpecialControl extends \FormSpecialPage {
 		return $text . $out;
 	}
 
-	public static function getControlStatus(\Title $title) {
+	public static function getControlStatus(Title $title) {
 		$id = $title->getArticleID();
 
 		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_REPLICA);
@@ -210,7 +219,7 @@ class SpecialControl extends \FormSpecialPage {
 		return intval($row->flowthread_ctrl_status);
 	}
 
-	public static function setControlStatus(\Title $title, $status) {
+	public static function setControlStatus(Title $title, $status) {
 		$id = $title->getArticleID();
 		$dbw = MediaWikiServices::getInstance()->getDBLoadBalancer()->getMaintenanceConnectionRef(DB_PRIMARY);
 		if ($status === self::STATUS_ENABLED) {

--- a/special/Export.php
+++ b/special/Export.php
@@ -2,9 +2,14 @@
 
 namespace FlowThread;
 
+use MediaWiki\Exception\PermissionsError;
+use MediaWiki\HTMLForm\HTMLForm;
+use MediaWiki\Json\FormatJson;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\Title\Title;
 
-class SpecialExport extends \SpecialPage {
+class SpecialExport extends SpecialPage {
 
 	public function __construct() {
 		parent::__construct('FlowThreadExport', 'commentadmin');
@@ -13,7 +18,7 @@ class SpecialExport extends \SpecialPage {
 	public function execute($par) {
 		$user = $this->getUser();
 		if (!$this->userCanExecute($user)) {
-			throw new \PermissionsError('commentadmin');
+			throw new PermissionsError('commentadmin');
 		}
 
 		$request = $this->getRequest();
@@ -69,8 +74,8 @@ class SpecialExport extends \SpecialPage {
 							echo "\n]},";
 						}
 						$pageid = $post->pageid;
-						$title = \Title::newFromId($pageid);
-						$title = \FormatJSON::encode($title ? $title->getPrefixedText() : '');
+						$title = Title::newFromId($pageid);
+						$title = FormatJSON::encode($title ? $title->getPrefixedText() : '');
 						echo "{\"title\":{$title}, \"posts\":[\n";
 						$first = true;
 					}
@@ -89,7 +94,7 @@ class SpecialExport extends \SpecialPage {
 						'parentid' => $post->parentid ? $post->parentid->getHex() : null,
 						'status' => $post->status,
 					);
-					echo '  ' . \FormatJSON::encode($postJSON);
+					echo '  ' . FormatJSON::encode($postJSON);
 				}
 			}
 			echo "\n]}]";
@@ -98,7 +103,7 @@ class SpecialExport extends \SpecialPage {
 		} else {
 			$formDescriptor = array();
 
-			$htmlForm = \HTMLForm::factory('div', $formDescriptor, $this->getContext(), 'flowthread_export_form');
+			$htmlForm = HTMLForm::factory('div', $formDescriptor, $this->getContext(), 'flowthread_export_form');
 
 			$htmlForm->setSubmitTextMsg('flowthreadexport-submit');
 			$htmlForm->show();

--- a/special/Link.php
+++ b/special/Link.php
@@ -1,9 +1,12 @@
 <?php
 namespace FlowThread;
 
+use MediaWiki\Exception\ErrorPageError;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\SpecialPage\RedirectSpecialPage;
+use MediaWiki\Title\Title;
 
-class SpecialLink extends \RedirectSpecialPage {
+class SpecialLink extends RedirectSpecialPage {
 
 	private $query = array();
 
@@ -39,10 +42,10 @@ class SpecialLink extends \RedirectSpecialPage {
 					}
 				}
 
-				return \Title::newFromId($post->pageid)->createFragmentTarget('comment-' . $subpage);
+				return Title::newFromId($post->pageid)->createFragmentTarget('comment-' . $subpage);
 			}
 		}
-		throw new \ErrorPageError('nopagetitle', 'nopagetext');
+		throw new ErrorPageError('nopagetitle', 'nopagetext');
 	}
 
 	public function getRedirectQuery($subpage) {

--- a/special/Manage.php
+++ b/special/Manage.php
@@ -1,9 +1,15 @@
 <?php
 namespace FlowThread;
 
+use MediaWiki\Exception\PermissionsError;
+use MediaWiki\Html\FormOptions;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\Title\Title;
+use MediaWiki\Xml\Xml;
 
-class SpecialManage extends \SpecialPage {
+class SpecialManage extends SpecialPage {
 
 	private $page;
 	private $user;
@@ -18,11 +24,11 @@ class SpecialManage extends \SpecialPage {
 	public function execute($par) {
 		$user = $this->getUser();
 		if (!$this->userCanExecute($user)) {
-			throw new \PermissionsError('commentadmin-restricted');
+			throw new PermissionsError('commentadmin-restricted');
 		}
 
 		// Parse request
-		$opt = new \FormOptions;
+		$opt = new FormOptions;
 		$opt->add('user', '');
 		$opt->add('page', '');
 		$opt->add('filter', 'all');
@@ -80,28 +86,28 @@ class SpecialManage extends \SpecialPage {
 
 		// This is essential as we need to submit the form to this page
 		$title = parent::getTitleFor('FlowThreadManage');
-		$html = \Html::hidden('title', $this->getPageTitle());
+		$html = Html::hidden('title', $this->getPageTitle());
 
 		$html .= $this->getTitleInput($this->page) . "\n";
 		$html .= $this->getUserInput($this->user) . "\n";
 		$html .= $this->getKeywordInput($this->keyword) . "\n";
 
-		$html .= \Xml::tags('p', null, $this->getFilterLinks($this->filter));
+		$html .= Xml::tags('p', null, $this->getFilterLinks($this->filter));
 
 		// Submit button
-		$html .= \Xml::submitButton($this->msg('allpagessubmit')->text());
+		$html .= Xml::submitButton($this->msg('allpagessubmit')->text());
 
 		// Fieldset
-		$html = \Xml::fieldset($this->msg('flowthreadmanage')->text(), $html);
+		$html = Xml::fieldset($this->msg('flowthreadmanage')->text(), $html);
 
 		// Wrap with a form
-		$html = \Xml::tags('form', array('action' => $wgScript, 'method' => 'get'), $html);
+		$html = Xml::tags('form', array('action' => $wgScript, 'method' => 'get'), $html);
 
 		if (MediaWikiServices::getInstance()->getPermissionManager()->userHasRight($this->getUser(), 'editinterface')) {
 			$link = MediaWikiServices::getInstance()->getLinkRenderer()
-				->makeKnownLink(\Title::newFromText('MediaWiki:Flowthread-blacklist'),
+				->makeKnownLink(Title::newFromText('MediaWiki:Flowthread-blacklist'),
 					$this->msg('flowthread-ui-editblacklist'));
-			$html .= \Xml::tags('small', array('style' => 'float:right;'), $link);
+			$html .= Xml::tags('small', array('style' => 'float:right;'), $link);
 		}
 
 		$this->getOutput()->addHTML($html);
@@ -124,7 +130,7 @@ class SpecialManage extends \SpecialPage {
 			}
 		}
 
-		$hiddens = \Html::hidden("filter", $current) . "\n";
+		$hiddens = Html::hidden("filter", $current) . "\n";
 
 		// Build links
 		return '<small>' . $this->getLanguage()->pipeList($links) . '</small>' . $hiddens;
@@ -137,7 +143,7 @@ class SpecialManage extends \SpecialPage {
 	}
 
 	private function getUserInput($user) {
-		$label = \Xml::inputLabel(
+		$label = Xml::inputLabel(
 			$this->msg('flowthreadmanage-user')->text(),
 			'user',
 			'',
@@ -150,7 +156,7 @@ class SpecialManage extends \SpecialPage {
 	}
 
 	private function getTitleInput($title) {
-		$label = \Xml::inputLabel(
+		$label = Xml::inputLabel(
 			$this->msg('flowthreadmanage-title')->text(),
 			'page',
 			'',
@@ -162,7 +168,7 @@ class SpecialManage extends \SpecialPage {
 	}
 
 	private function getKeywordInput($keyword) {
-		$label = \Xml::inputLabel(
+		$label = Xml::inputLabel(
 			$this->msg('flowthreadmanage-keyword')->text(),
 			'keyword',
 			'',


### PR DESCRIPTION
1. Some class aliases will remove in MediaWiki 1.44, use great classname instead [0]
2. Some class aliases already deprecated the older versions, in the case, use great classname instead

[0] https://github.com/wikimedia/mediawiki/commit/fcbb75b8a496e18f12872845c69f8c92e3c55c4d